### PR TITLE
Improve 30c3 serw.py reliability

### DIFF
--- a/board/30c3/boardsw-v2/highcompatibility/GeneralPlusRomWrite/GeneralPlusRomWrite.ino
+++ b/board/30c3/boardsw-v2/highcompatibility/GeneralPlusRomWrite/GeneralPlusRomWrite.ino
@@ -1,0 +1,109 @@
+#include <SPI.h>
+
+#define SLAVESELECT 17//ss
+
+//opcodes
+#define WREN  6
+#define WRDI  4
+#define RDSR  5
+#define WRSR  1
+#define READ  3
+#define WRITE 2
+#define SECTOR_ERASE 0xd8
+
+long int once = 0;
+
+void setup()
+{
+  Serial.begin(115200);
+
+  SPI.begin();
+  digitalWrite(SLAVESELECT, HIGH); //disable device
+  SPI.beginTransaction(SPISettings(1000000, MSBFIRST, SPI_MODE0));
+
+  while (!Serial) {}
+  Serial.print("serial test \r\n");
+}
+
+void loop()
+{
+  long int i;
+  byte b[256];
+  byte status_reg;
+
+  for (i = 0; i < 256; ) {
+    i += Serial.readBytes((char*)b+i, 16);
+    Serial.println(".");
+  }
+
+  if ((once % 256) == 0) {
+    // eeprom_output_data = read_eeprom(address);
+    Serial.print("Sector erase: ");
+    Serial.println(once / 256);
+    digitalWrite(SLAVESELECT, LOW);
+    SPI.transfer(WREN);  // Write enable
+    digitalWrite(SLAVESELECT, HIGH);
+
+    digitalWrite(SLAVESELECT, LOW);
+    SPI.transfer(RDSR);
+    status_reg = SPI.transfer(0x0);
+    digitalWrite(SLAVESELECT, HIGH);
+    if ((status_reg & 0x02) == 0) {
+      Serial.println("FAIL: write enable failed");
+      once = 0;
+      return;
+    }
+
+    digitalWrite(SLAVESELECT, LOW);
+    SPI.transfer(SECTOR_ERASE);  // Sector erase
+    SPI.transfer(once / 256);
+    SPI.transfer(0x00);
+    SPI.transfer(0x00);
+    digitalWrite(SLAVESELECT, HIGH);
+
+    while ((status_reg & 0x1) == 0) {
+      digitalWrite(SLAVESELECT, LOW);
+      SPI.transfer(RDSR);
+      status_reg = SPI.transfer(0x0);
+      digitalWrite(SLAVESELECT, HIGH);
+    }
+    Serial.println("Sector erase: finished");
+  }
+
+  Serial.print("Page program: ");
+  Serial.println(once);
+  digitalWrite(SLAVESELECT, LOW);
+  SPI.transfer(WREN); // Write enable
+  digitalWrite(SLAVESELECT, HIGH);
+
+  digitalWrite(SLAVESELECT, LOW);
+  SPI.transfer(RDSR);
+  status_reg = SPI.transfer(0x0);
+  digitalWrite(SLAVESELECT, HIGH);
+  if ((status_reg & 0x02) == 0) {
+    Serial.println("FAIL: write enable failed");
+    once = 0;
+    return;
+  }
+
+  digitalWrite(SLAVESELECT, LOW);
+  SPI.transfer(WRITE);  // Page program
+  SPI.transfer(once / 256);
+  SPI.transfer(once % 256);
+  SPI.transfer(0);
+  SPI.transfer(b, 256);
+  digitalWrite(SLAVESELECT, HIGH);
+
+  while ((status_reg & 0x1) == 0) {
+    digitalWrite(SLAVESELECT, LOW);
+    SPI.transfer(RDSR);
+    status_reg = SPI.transfer(0x0);
+    digitalWrite(SLAVESELECT, HIGH);
+  }
+
+  Serial.println("Page program: finished");
+
+  once++;
+}
+
+

--- a/board/30c3/boardsw-v2/serw.py
+++ b/board/30c3/boardsw-v2/serw.py
@@ -1,0 +1,53 @@
+import serial
+import time
+import sys
+
+#enter your device file
+arddev = sys.argv[1]
+baud = 115200
+
+#setup - if a Serial object can't be created, a SerialException will be raised.
+start_time = time.time()
+
+while True:
+    try:
+        ser = serial.Serial(arddev, baud)
+
+        #break out of while loop when connection is made
+        break
+    except serial.SerialException:
+        print 'waiting for device ' + arddev + ' to be available'
+        time.sleep(3)
+
+#read lines from serial device
+f = open(sys.argv[2], 'rb')
+b = f.read()
+a = 0;
+print "Start"
+start_time = time.time()
+while True:
+	ser.write(b[a:a+16])
+        ser.flush()
+
+	a = a + 16
+
+        if (a % 256) == 0:
+            print (a * 1.0/0x7ffff *100.0)
+
+        while True:
+            status_line = ser.readline().strip();
+            if status_line[0] == '.':
+                break
+            elif status_line[0:5] == "FAIL:":
+                print status_line
+                print "Write failed"
+                exit()
+            else:
+                print status_line
+
+	if (a>0x7ffff):
+		print "Complete!"
+		# your code
+		elapsed_time = time.time() - start_time
+		print elapsed_time
+		exit()


### PR DESCRIPTION
Arduino Serial uses a fairly small buffer.  Attempting to send 256 bytes
at a time can easily overflow the buffer before it can be drained by the
main loop and cause problems.  By writing 16 bytes at a time, the buffer
doesn't seem to overflow.

While debugging this, I added checks that the write operations are
actually completed by the flash chip. This removes the explicit delay()
and makes it very obvious when the figure isn't connected (either an
explicit failure message _or_ the progress output stops).

Verified it works on macOS.  Didn't try Windows or Linux though it
should work.