### PR TITLE
30c3 boardsw-v2: Fix write-in-progress polling

### DIFF
--- a/board/30c3/boardsw-v2/highcompatibility/GeneralPlusRomWrite/GeneralPlusRomWrite.ino
+++ b/board/30c3/boardsw-v2/highcompatibility/GeneralPlusRomWrite/GeneralPlusRomWrite.ino
@@ -29,7 +29,7 @@ void loop()
 {
   long int i;
   byte b[256];
-  byte status_reg;
+  byte status_reg = 0;
 
   for (i = 0; i < 256; ) {
     i += Serial.readBytes((char*)b+i, 16);
@@ -61,12 +61,14 @@ void loop()
     SPI.transfer(0x00);
     digitalWrite(SLAVESELECT, HIGH);
 
-    while ((status_reg & 0x1) == 0) {
+    do {
       digitalWrite(SLAVESELECT, LOW);
       SPI.transfer(RDSR);
       status_reg = SPI.transfer(0x0);
       digitalWrite(SLAVESELECT, HIGH);
-    }
+      Serial.print("Status reg: ");
+      Serial.println(status_reg, HEX);
+    } while ((status_reg & 0x1) == 1);
     Serial.println("Sector erase: finished");
   }
 
@@ -91,15 +93,19 @@ void loop()
   SPI.transfer(once / 256);
   SPI.transfer(once % 256);
   SPI.transfer(0);
-  SPI.transfer(b, 256);
+  for (int i = 0; i < 256; i++) {
+    SPI.transfer(b[i]);
+  }
   digitalWrite(SLAVESELECT, HIGH);
 
-  while ((status_reg & 0x1) == 0) {
+  do {
     digitalWrite(SLAVESELECT, LOW);
     SPI.transfer(RDSR);
     status_reg = SPI.transfer(0x0);
     digitalWrite(SLAVESELECT, HIGH);
-  }
+    Serial.print("Status reg: ");
+    Serial.println(status_reg, HEX);
+  } while ((status_reg & 0x1) == 1);
 
   Serial.println("Page program: finished");
 


### PR DESCRIPTION
Status register bit 0 is set to 1 while a write is in progress, not 0.  Also
change to a do/while to ensure the status register is read at least once.